### PR TITLE
Make tests pass with both new and old DateTime::Locale

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for MooseX-Types-DateTime
 
 {{$NEXT}}
+        - make all tests pass with both the current DateTime::Locale and the
+          upcoming new version (currently still in trial releases).
 
 0.12      2015-09-27 05:01:39Z
         - fix new test that may fail with older Moose

--- a/lib/MooseX/Types/DateTime.pm
+++ b/lib/MooseX/Types/DateTime.pm
@@ -13,7 +13,7 @@ use DateTime::Duration 0.4302 ();
 use DateTime::Locale 0.4001 ();
 use DateTime::TimeZone 0.95 ();
 
-use MooseX::Types::Moose 0.30 qw/Num HashRef Str/;
+use MooseX::Types::Moose 0.30 qw/Num HashRef Object Str/;
 
 use namespace::clean 0.19;
 
@@ -23,12 +23,14 @@ use if MooseX::Types->VERSION >= 0.42, 'namespace::autoclean';
 class_type "DateTime";
 class_type "DateTime::Duration";
 class_type "DateTime::TimeZone";
-class_type "DateTime::Locale::root" => { name => "DateTime::Locale" };
 
 subtype DateTime, as 'DateTime';
 subtype Duration, as 'DateTime::Duration';
 subtype TimeZone, as 'DateTime::TimeZone';
-subtype Locale,   as 'DateTime::Locale';
+
+subtype 'DateTime::Locale', as Object,
+    where { $_->isa('DateTime::Locale::root') || $_->isa('DateTime::Locale::FromData') };
+subtype Locale, as 'DateTime::Locale';
 
 subtype( Now,
     as Str,

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -101,7 +101,7 @@ isa_ok( find_type_constraint($_), "Moose::Meta::TypeConstraint" ) for qw(DateTim
 
     my $loc = Gorch->new( loc => "he_IL" )->loc;
 
-    isa_ok( $loc, "DateTime::Locale::he", "coerced from string" );
+    like( $loc->id, qr/he[_\-]IL/, "coerced from string" );
 
     like(exception { Gorch->new( loc => "not_a_place_or_a_locale" ) }, qr/Invalid locale/, "bad locale name");
 
@@ -124,7 +124,7 @@ isa_ok( find_type_constraint($_), "Moose::Meta::TypeConstraint" ) for qw(DateTim
 
         isa_ok( $handle, "Some::L10N", "maketext handle" );
 
-        isa_ok( Gorch->new( loc => $handle )->loc, "DateTime::Locale::ja", "coerced from maketext" );;
+        is( Gorch->new( loc => $handle )->loc->id, "ja", "coerced from maketext" );;
     }
 }
 


### PR DESCRIPTION
There's a not-quite-yet-released trial version of DateTime::Locale which should go out in the next few hours. That will fix the remaining failures not addressed by this PR.
